### PR TITLE
Allow anyone to create a loan

### DIFF
--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -26,12 +26,12 @@ contract LoanFactory {
      * @dev Creates a Loan
      * @dev Emits `LoanCreated` event.
      */
-    function createLoan(address pool, uint256 dropDeadDate)
-        public
-        virtual
-        returns (address LoanAddress)
-    {
-        Loan loan = new Loan(msg.sender, pool, dropDeadDate);
+    function createLoan(
+        address borrower,
+        address pool,
+        uint256 dropDeadDate
+    ) public virtual returns (address LoanAddress) {
+        Loan loan = new Loan(borrower, pool, dropDeadDate);
         address addr = address(loan);
         emit LoanCreated(addr);
         return addr;

--- a/test/Loan.test.ts
+++ b/test/Loan.test.ts
@@ -61,9 +61,11 @@ describe("Loan", () => {
     const pool = Pool.attach(poolAddress);
 
     // Create the Loan
-    const tx2 = await loanFactory
-      .connect(borrower)
-      .createLoan(poolAddress, Math.floor(Date.now() / 1000) + SEVEN_DAYS);
+    const tx2 = await loanFactory.createLoan(
+      borrower.address,
+      poolAddress,
+      Math.floor(Date.now() / 1000) + SEVEN_DAYS
+    );
     const tx2Receipt = await tx2.wait();
 
     const loanCreatedEvent = findEventByName(tx2Receipt, "LoanCreated");


### PR DESCRIPTION
This allows anyone to create a loan.

We could theoretically bind this to a pool and require the PM to perform the action. However, it's unnecessary. After creation, there are 2 subsequent steps that must be performed to ensure borrower is "valid".

PM will need to fund
Borrower will need to drawdown

This may lead to a case where the borrower isn't whitelisted. That is something that can be checked off-chain before creating the loan, before funding the loan, or waiting for borrower to drawdown which would check on-chain.