### PR TITLE
VAL-23 Implement rounding per 4626

### DIFF
--- a/contracts/libraries/PoolLib.sol
+++ b/contracts/libraries/PoolLib.sol
@@ -219,48 +219,28 @@ library PoolLib {
 
     /**
      * @dev Computes the exchange rate for converting assets to shares
-     * @param assets Amount of assets to exchange
-     * @param totalAvailableShares Supply of Vault's ERC20 shares (excluding marked for redemption)
-     * @param totalAvailableAssets Pool total available assets (excluding marked for withdrawal)
-     * @return shares The amount of shares
+     * @param input The input to the conversion
+     * @param numerator Numerator of the conversion rate
+     * @param denominator Denominator of the conversion rate
+     * @param roundUp Whether it should be rounded up or down.
+     * @return output The converted amount
      */
-    function calculateAssetsToShares(
-        uint256 assets,
-        uint256 totalAvailableShares,
-        uint256 totalAvailableAssets
-    ) external pure returns (uint256 shares) {
-        if (totalAvailableAssets == 0) {
-            return assets;
+    function calculateConversion(
+        uint256 input,
+        uint256 numerator,
+        uint256 denominator,
+        bool roundUp
+    ) external pure returns (uint256 output) {
+        if (numerator == 0) {
+            return input;
         }
 
-        // TODO: add in interest rate.
-        uint256 rate = (totalAvailableShares.mul(RAY)).div(
-            totalAvailableAssets
-        );
-        shares = (rate.mul(assets)).div(RAY);
-    }
-
-    /**
-     * @dev Computes the exchange rate for converting shares to assets
-     * @param shares Amount of shares to exchange
-     * @param totalAvailableShares Supply of Vault's ERC20 shares (excluding marked for redemption)
-     * @param totalAvailableAssets Pool total available assets (excluding marked for withdrawal)
-     * @return assets The amount of shares
-     */
-    function calculateSharesToAssets(
-        uint256 shares,
-        uint256 totalAvailableShares,
-        uint256 totalAvailableAssets
-    ) external pure returns (uint256 assets) {
-        if (totalAvailableShares == 0) {
-            return shares;
+        uint256 rate = numerator.mul(RAY).div(denominator);
+        if (roundUp) {
+            return divideCeil(rate.mul(input), RAY);
+        } else {
+            return rate.mul(input).div(RAY);
         }
-
-        // TODO: add in interest rate.
-        uint256 rate = (totalAvailableAssets.mul(RAY)).div(
-            totalAvailableShares
-        );
-        assets = (rate.mul(shares)).div(RAY);
     }
 
     /**

--- a/contracts/mocks/PoolLibTestWrapper.sol
+++ b/contracts/mocks/PoolLibTestWrapper.sol
@@ -64,20 +64,14 @@ contract PoolLibTestWrapper is ERC20("PoolLibTest", "PLT") {
             );
     }
 
-    function calculateAssetsToShares(
-        uint256 assets,
-        uint256 sharesTotalSupply,
-        uint256 nav
+    function calculateConversion(
+        uint256 input,
+        uint256 numerator,
+        uint256 denominator,
+        bool roundUp
     ) external pure returns (uint256) {
-        return PoolLib.calculateAssetsToShares(assets, sharesTotalSupply, nav);
-    }
-
-    function calculateSharesToAssets(
-        uint256 shares,
-        uint256 sharesTotalSupply,
-        uint256 nav
-    ) external pure returns (uint256 assets) {
-        return PoolLib.calculateSharesToAssets(shares, sharesTotalSupply, nav);
+        return
+            PoolLib.calculateConversion(input, numerator, denominator, roundUp);
     }
 
     function calculateTotalAssets(

--- a/test/libraries/PoolLib.test.ts
+++ b/test/libraries/PoolLib.test.ts
@@ -533,55 +533,61 @@ describe("PoolLib", () => {
     });
   });
 
-  describe("calculateAssetsToShares()", async () => {
-    it("calculates 1:1 shares if token supply is zero", async () => {
-      const { poolLibWrapper } = await loadFixture(deployFixture);
-
-      expect(await poolLibWrapper.calculateAssetsToShares(500, 0, 0)).to.equal(
-        500
-      );
-    });
-
-    it("calculates <1:1 if nav has increased in value, and properly rounds down", async () => {
+  describe("calculateConversion()", async () => {
+    it("calculates 1:1 if starting from 0", async () => {
       const { poolLibWrapper } = await loadFixture(deployFixture);
 
       expect(
-        await poolLibWrapper.calculateAssetsToShares(500, 500, 525)
+        await poolLibWrapper.calculateConversion(500, 0, 0, false)
+      ).to.equal(500);
+    });
+
+    it("calculates <1:1 ratio correctly rounding down", async () => {
+      const { poolLibWrapper } = await loadFixture(deployFixture);
+
+      expect(
+        await poolLibWrapper.calculateConversion(500, 500, 525, false)
       ).to.equal(476) /* 476.19 rounded down */;
     });
 
-    it("calculates >1:1 if nav has decreased in value, and properly rounds down", async () => {
+    it("calculates 1:1 ratio correctly rounding down", async () => {
       const { poolLibWrapper } = await loadFixture(deployFixture);
 
       expect(
-        await poolLibWrapper.calculateAssetsToShares(500, 500, 399)
+        await poolLibWrapper.calculateConversion(500, 500, 500, false)
+      ).to.equal(500);
+    });
+
+    it("calculates >1:1 ratio correctly rounding down", async () => {
+      const { poolLibWrapper } = await loadFixture(deployFixture);
+
+      expect(
+        await poolLibWrapper.calculateConversion(500, 500, 399, false)
       ).to.equal(626); /* 626.53 rounded down */
     });
-  });
 
-  describe("calculateSharesToAssets()", async () => {
-    it("calculates 1:1 assets if token supply is zero", async () => {
-      const { poolLibWrapper } = await loadFixture(deployFixture);
-
-      expect(await poolLibWrapper.calculateAssetsToShares(500, 0, 0)).to.equal(
-        500
-      );
-    });
-
-    it("calculates <1:1 if nav has increased in value, and properly rounds down", async () => {
+    it("calculates <1:1 ratio correctly rounding up", async () => {
       const { poolLibWrapper } = await loadFixture(deployFixture);
 
       expect(
-        await poolLibWrapper.calculateAssetsToShares(500, 500, 525)
-      ).to.equal(476); /* 476.19 rounded down */
+        await poolLibWrapper.calculateConversion(500, 500, 525, true)
+      ).to.equal(477) /* 476.19 rounded up */;
     });
 
-    it("calculates >1:1 if nav has decreased in value, and properly rounds down", async () => {
+    it("calculates 1:1 ratio correctly rounding up", async () => {
       const { poolLibWrapper } = await loadFixture(deployFixture);
 
       expect(
-        await poolLibWrapper.calculateAssetsToShares(500, 500, 399)
-      ).to.equal(626); /* 626.53 rounded down */
+        await poolLibWrapper.calculateConversion(500, 500, 500, true)
+      ).to.equal(500);
+    });
+
+    it("calculates >1:1 ratio correctly rounding up", async () => {
+      const { poolLibWrapper } = await loadFixture(deployFixture);
+
+      expect(
+        await poolLibWrapper.calculateConversion(500, 500, 399, true)
+      ).to.equal(627); /* 626.53 rounded up */
     });
   });
 


### PR DESCRIPTION
Updates the rounding per 4626 to round UP in certain cases. Per 4626, 

- `convertToAssets`, `convertToShares` should both round DOWN
- `previewDeposit`, and `deposit` should round DOWN (i.e. calculating how many Y shares to mint for X assets)
- `previewMint`, and `mint` should round UP (i.e. calculating how many Y assets to transfer from lender to mint X shares)
- `previewWithdraw`, and `withdraw` rounds UP (i.e. calculating how many shares required to withdraw assets)
- `previewRedeem`, and `redeem` rounds DOWN (i.e. calculating how many assets to transfer TO lender for X shares)

Please sanity check that's correct: https://eips.ethereum.org/EIPS/eip-4626#security-considerations

Also simplified some of the PoolLib methods since they were duplicative at this point (consolidated to a single `PoolLib.calculateConversion` method).