### PR TITLE
Add PoolController to handle pool admin tasks

### DIFF
--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -3,20 +3,16 @@ pragma solidity ^0.8.16;
 
 import "./Pool.sol";
 import "./interfaces/IServiceConfiguration.sol";
+import "./interfaces/IPoolFactory.sol";
 
 /**
  * @title PoolFactory
  */
-contract PoolFactory {
+contract PoolFactory is IPoolFactory {
     /**
      * @dev Reference to the ServiceConfiguration contract
      */
     address private _serviceConfiguration;
-
-    /**
-     * @dev Emitted when a pool is created.
-     */
-    event PoolCreated(address indexed addr);
 
     constructor(address serviceConfiguration) {
         _serviceConfiguration = serviceConfiguration;
@@ -29,6 +25,7 @@ contract PoolFactory {
     function createPool(
         address liquidityAsset,
         address withdrawControllerFactory,
+        address poolControllerFactory,
         IPoolConfigurableSettings calldata settings
     ) public virtual returns (address poolAddress) {
         require(
@@ -40,7 +37,8 @@ contract PoolFactory {
             "PoolFactory: Invalid duration"
         );
         require(
-            withdrawControllerFactory != address(0),
+            withdrawControllerFactory != address(0) &&
+                poolControllerFactory != address(0),
             "PoolFactory: Invalid address"
         );
         if (settings.fixedFee > 0) {
@@ -56,6 +54,7 @@ contract PoolFactory {
             msg.sender,
             _serviceConfiguration,
             withdrawControllerFactory,
+            poolControllerFactory,
             settings,
             "PerimeterPoolToken",
             "PPT"

--- a/contracts/controllers/PoolController.sol
+++ b/contracts/controllers/PoolController.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+import "../interfaces/IPool.sol";
+import "./interfaces/IPoolController.sol";
+import "../libraries/PoolLib.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+/**
+ * @title WithdrawState
+ */
+contract PoolController is IPoolController {
+    IPool public pool;
+    address public admin;
+    IPoolConfigurableSettings private _settings;
+    IPoolLifeCycleState private _state;
+
+    /**
+     * @dev Modifier that checks that the caller is the pool's admin.
+     */
+    modifier onlyAdmin() {
+        require(
+            admin != address(0) && msg.sender == admin,
+            "Pool: caller is not admin"
+        );
+        _;
+    }
+
+    /**
+     * @dev Modifier that checks that the pool is Initialized or Active
+     */
+    modifier atState(IPoolLifeCycleState state_) {
+        require(state() == state_, "Pool: FunctionInvalidAtThisLifeCycleState");
+        _;
+    }
+
+    /**
+     * @dev Modifier that checks that the pool is Initialized or Active
+     */
+    modifier atInitializedOrActiveState() {
+        IPoolLifeCycleState _currentState = state();
+
+        require(
+            _currentState == IPoolLifeCycleState.Active ||
+                _currentState == IPoolLifeCycleState.Initialized,
+            "Pool: invalid pool state"
+        );
+        _;
+    }
+
+    constructor(
+        address pool_,
+        address admin_,
+        IPoolConfigurableSettings memory poolSettings_
+    ) {
+        pool = IPool(pool_);
+        admin = admin_;
+        _settings = poolSettings_;
+
+        _setState(IPoolLifeCycleState.Initialized);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                Settings
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function settings()
+        external
+        view
+        returns (IPoolConfigurableSettings memory)
+    {
+        return _settings;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function setRequestFee(uint256 feeBps)
+        external
+        onlyAdmin
+        atState(IPoolLifeCycleState.Initialized)
+    {
+        _settings.requestFeeBps = feeBps;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function requestFee(uint256 sharesOrAssets)
+        public
+        view
+        returns (uint256 feeShares)
+    {
+        feeShares = PoolLib.calculateRequestFee(
+            sharesOrAssets,
+            _settings.requestFeeBps
+        );
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function setWithdrawGate(uint256 _withdrawGateBps)
+        external
+        onlyAdmin
+        atInitializedOrActiveState
+    {
+        _settings.withdrawGateBps = _withdrawGateBps;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function withdrawGate() public view returns (uint256) {
+        if (state() == IPoolLifeCycleState.Closed) {
+            return 10_000;
+        }
+
+        return _settings.withdrawGateBps;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function setPoolCapacity(uint256 newCapacity) external onlyAdmin {
+        require(newCapacity >= pool.totalAssets(), "Pool: invalid capacity");
+        _settings.maxCapacity = newCapacity;
+        emit PoolSettingsUpdated();
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function setPoolEndDate(uint256 endDate) external onlyAdmin {
+        require(_settings.endDate > endDate, "Pool: can't move end date up");
+        require(
+            endDate > block.timestamp,
+            "Pool: can't move end date into the past"
+        );
+        _settings.endDate = endDate;
+        emit PoolSettingsUpdated();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                State
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function state() public view returns (IPoolLifeCycleState) {
+        if (block.timestamp >= _settings.endDate) {
+            return IPoolLifeCycleState.Closed;
+        }
+
+        return _state;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function isInitializedOrActive() external view returns (bool) {
+        IPoolLifeCycleState _currentState = state();
+
+        return
+            _currentState == IPoolLifeCycleState.Initialized ||
+            _currentState == IPoolLifeCycleState.Active;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function isActiveOrClosed() external view returns (bool) {
+        IPoolLifeCycleState _currentState = state();
+
+        return
+            _currentState == IPoolLifeCycleState.Active ||
+            _currentState == IPoolLifeCycleState.Closed;
+    }
+
+    /**
+     * @dev Set the pool lifecycle state. If the state changes, this method
+     * will also update the activatedAt variable
+     */
+    function _setState(IPoolLifeCycleState newState) internal {
+        if (_state != newState) {
+            if (
+                newState == IPoolLifeCycleState.Active &&
+                pool.activatedAt() == 0
+            ) {
+                pool.onActivated();
+            }
+
+            _state = newState;
+            emit LifeCycleStateTransition(newState);
+        }
+    }
+
+    // /////////////////////////////////////////////////
+    // Actions
+    // /////////////////////////////////////////////////
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function depositFirstLoss(uint256 amount, address spender)
+        external
+        onlyAdmin
+        atInitializedOrActiveState
+    {
+        pool.transferToFirstLossVault(spender, amount);
+        IPoolLifeCycleState poolLifeCycleState = PoolLib
+            .executeFirstLossDeposit(
+                pool.asset(),
+                spender,
+                amount,
+                pool.firstLossVault(),
+                state(),
+                _settings.firstLossInitialMinimum
+            );
+
+        _setState(poolLifeCycleState);
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function withdrawFirstLoss(uint256 amount, address receiver)
+        external
+        onlyAdmin
+        atState(IPoolLifeCycleState.Closed)
+        returns (uint256)
+    {
+        require(pool.numFundedLoans() == 0, "Pool: loans still active");
+
+        pool.transferFromFirstLossVault(receiver, amount);
+
+        return
+            PoolLib.executeFirstLossWithdraw(
+                amount,
+                receiver,
+                pool.firstLossVault()
+            );
+    }
+}

--- a/contracts/controllers/WithdrawController.sol
+++ b/contracts/controllers/WithdrawController.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.16;
 
 import "../interfaces/IPool.sol";
 import "./interfaces/IWithdrawController.sol";
+import "./interfaces/IPoolController.sol";
 import "../libraries/PoolLib.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
@@ -63,7 +64,7 @@ contract WithdrawController is IWithdrawController {
     function withdrawPeriod() public view returns (uint256 period) {
         period = PoolLib.calculateCurrentWithdrawPeriod(
             block.timestamp,
-            _pool.poolActivatedAt(),
+            _pool.activatedAt(),
             _pool.settings().withdrawRequestPeriodDuration
         );
     }
@@ -342,9 +343,12 @@ contract WithdrawController is IWithdrawController {
     function crank() external onlyPool returns (uint256 redeemableShares) {
         // Calculate the amount available for withdrawal
         uint256 liquidAssets = _pool.liquidityPoolAssets();
+        IPoolController _poolController = IPoolController(
+            _pool.poolController()
+        );
 
         uint256 availableAssets = liquidAssets
-            .mul(_pool.withdrawGate())
+            .mul(_poolController.withdrawGate())
             .mul(PoolLib.RAY)
             .div(10_000)
             .div(PoolLib.RAY);

--- a/contracts/controllers/interfaces/IPoolController.sol
+++ b/contracts/controllers/interfaces/IPoolController.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+import "../../interfaces/IPool.sol";
+
+/**
+ * @dev Expresses the various states a pool can be in throughout its lifecycle.
+ */
+enum IPoolLifeCycleState {
+    Initialized,
+    Active,
+    Paused,
+    Closed
+}
+
+/**
+ * @title The various configurable settings that customize Pool behavior.
+ */
+struct IPoolConfigurableSettings {
+    uint256 maxCapacity; // amount
+    uint256 endDate; // epoch seconds
+    uint256 requestFeeBps; // bips
+    uint256 requestCancellationFeeBps; // bips
+    uint256 withdrawGateBps; // Percent of liquidity pool available to withdraw, represented in BPS
+    uint256 firstLossInitialMinimum; // amount
+    uint256 withdrawRequestPeriodDuration; // seconds (e.g. 30 days)
+    uint256 fixedFee;
+    uint256 fixedFeeInterval;
+    uint256 poolFeePercentOfInterest; // bips
+}
+
+/**
+ * @title A Pool's Admin controller
+ */
+interface IPoolController {
+    /**
+     * @dev Emitted when pool settings are updated.
+     */
+    event PoolSettingsUpdated();
+
+    /**
+     * @dev Emitted when the pool transitions a lifecycle state.
+     */
+    event LifeCycleStateTransition(IPoolLifeCycleState state);
+
+    /*//////////////////////////////////////////////////////////////
+                Settings
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev The current configurable pool settings.
+     */
+    function settings()
+        external
+        view
+        returns (IPoolConfigurableSettings memory);
+
+    /**
+     * @dev Allow the current pool admin to update the pool fees
+     * before the pool has been activated.
+     */
+    function setRequestFee(uint256) external;
+
+    /**
+     * @dev Returns the redeem fee for a given withdrawal amount at the current block.
+     * The fee is the number of shares that will be charged.
+     */
+    function requestFee(uint256) external view returns (uint256);
+
+    /**
+     * @dev Allow the current pool admin to update the withdraw gate at any
+     * time if the pool is Initialized or Active
+     */
+    function setWithdrawGate(uint256) external;
+
+    /**
+     * @dev Returns the current withdraw gate in bps. If the pool is closed,
+     * this is set to 10_000 (100%)
+     */
+    function withdrawGate() external view returns (uint256);
+
+    /**
+     * @dev
+     */
+    function setPoolCapacity(uint256) external;
+
+    /**
+     * @dev
+     */
+    function setPoolEndDate(uint256) external;
+
+    /*//////////////////////////////////////////////////////////////
+                State
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Returns the current pool lifecycle state.
+     */
+    function state() external view returns (IPoolLifeCycleState);
+
+    /**
+     * @dev Returns true if the pool is in an active or initialized state
+     */
+    function isInitializedOrActive() external view returns (bool);
+
+    /**
+     * @dev Returns true if the pool is in an active or closed state
+     */
+    function isActiveOrClosed() external view returns (bool);
+
+    /*//////////////////////////////////////////////////////////////
+                First Loss
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Deposits first-loss to the pool. Can only be called by the Pool Admin.
+     */
+    function depositFirstLoss(uint256 amount, address spender) external;
+
+    /**
+     * @dev Withdraws first-loss from the pool. Can only be called by the Pool Admin.
+     */
+    function withdrawFirstLoss(uint256 amount, address receiver)
+        external
+        returns (uint256);
+}

--- a/contracts/factories/PoolControllerFactory.sol
+++ b/contracts/factories/PoolControllerFactory.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+import "../controllers/PoolController.sol";
+import "../interfaces/IServiceConfiguration.sol";
+import "./interfaces/IPoolControllerFactory.sol";
+
+/**
+ * @title PoolAdmin controller Factory
+ */
+contract PoolControllerFactory is IPoolControllerFactory {
+    /**
+     * @dev Reference to the ServiceConfiguration contract
+     */
+    address private _serviceConfiguration;
+
+    constructor(address serviceConfiguration) {
+        _serviceConfiguration = serviceConfiguration;
+    }
+
+    /**
+     * @inheritdoc IPoolControllerFactory
+     */
+    function createController(
+        address pool,
+        address admin,
+        IPoolConfigurableSettings memory poolSettings
+    ) public virtual returns (address addr) {
+        require(
+            IServiceConfiguration(_serviceConfiguration).paused() == false,
+            "PoolControllerFactory: Protocol paused"
+        );
+
+        PoolController controller = new PoolController(
+            pool,
+            admin,
+            poolSettings
+        );
+        addr = address(controller);
+        emit PoolControllerCreated(addr, admin);
+    }
+}

--- a/contracts/factories/WithdrawControllerFactory.sol
+++ b/contracts/factories/WithdrawControllerFactory.sol
@@ -21,7 +21,7 @@ contract WithdrawControllerFactory is IWithdrawControllerFactory {
     /**
      * @inheritdoc IWithdrawControllerFactory
      */
-    function createWithdrawController(address pool)
+    function createController(address pool)
         public
         virtual
         returns (address addr)

--- a/contracts/factories/interfaces/IPoolControllerFactory.sol
+++ b/contracts/factories/interfaces/IPoolControllerFactory.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+import "../../interfaces/IPool.sol";
+
+/**
+ * @title The interface for controlling access to Pools
+ */
+interface IPoolControllerFactory {
+    /**
+     * @dev Emitted when a pool is created.
+     */
+    event PoolControllerCreated(address indexed pool, address indexed addr);
+
+    /**
+     * @dev Creates a pool's PoolAdmin controller
+     * @dev Emits `PoolControllerCreated` event.
+     */
+    function createController(
+        address,
+        address,
+        IPoolConfigurableSettings memory
+    ) external returns (address);
+}

--- a/contracts/factories/interfaces/IWithdrawControllerFactory.sol
+++ b/contracts/factories/interfaces/IWithdrawControllerFactory.sol
@@ -14,5 +14,5 @@ interface IWithdrawControllerFactory {
      * @dev Creates a pool's withdraw controller
      * @dev Emits `WithdrawControllerCreated` event.
      */
-    function createWithdrawController(address) external returns (address);
+    function createController(address) external returns (address);
 }

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+import "../interfaces/IPool.sol";
+
+/**
+ * @title The PoolFactory
+ */
+interface IPoolFactory {
+    /**
+     * @dev Emitted when a pool is created.
+     */
+    event PoolCreated(address indexed addr);
+
+    /**
+     * @dev Creates a pool's PoolAdmin controller
+     * @dev Emits `PoolControllerCreated` event.
+     */
+    function createPool(
+        address,
+        address,
+        address,
+        IPoolConfigurableSettings calldata
+    ) external returns (address);
+}

--- a/contracts/libraries/PoolLib.sol
+++ b/contracts/libraries/PoolLib.sol
@@ -102,22 +102,6 @@ library PoolLib {
     }
 
     /**
-     * @dev Updates the Pool End Date.
-     */
-    function executeUpdateEndDate(
-        uint256 endDate,
-        IPoolConfigurableSettings storage settings
-    ) external {
-        require(settings.endDate > endDate, "Pool: can't move end date up");
-        require(
-            endDate > block.timestamp,
-            "Pool: can't move end date into the past"
-        );
-        settings.endDate = endDate;
-        emit PoolSettingsUpdated();
-    }
-
-    /**
      * @dev Transfers first loss to the vault.
      * @param liquidityAsset Pool liquidity asset
      * @param amount Amount of first loss being contributed
@@ -135,11 +119,6 @@ library PoolLib {
     ) external returns (IPoolLifeCycleState newState) {
         require(firstLossVault != address(0), "Pool: 0 address");
 
-        IERC20(liquidityAsset).safeTransferFrom(
-            spender,
-            firstLossVault,
-            amount
-        );
         newState = currentState;
 
         // Graduate pool state if needed
@@ -151,6 +130,7 @@ library PoolLib {
         ) {
             newState = IPoolLifeCycleState.Active;
         }
+
         emit FirstLossDeposited(msg.sender, spender, amount);
     }
 
@@ -169,7 +149,6 @@ library PoolLib {
         require(firstLossVault != address(0), "Pool: 0 address");
         require(withdrawReceiver != address(0), "Pool: 0 address");
 
-        FirstLossVault(firstLossVault).withdraw(amount, withdrawReceiver);
         emit FirstLossWithdrawn(msg.sender, withdrawReceiver, amount);
         return amount;
     }

--- a/contracts/permissioned/PermissionedPool.sol
+++ b/contracts/permissioned/PermissionedPool.sol
@@ -46,6 +46,7 @@ contract PermissionedPool is Pool {
         address poolAdmin,
         address serviceConfiguration,
         address withdrawController,
+        address poolController,
         IPoolConfigurableSettings memory poolSettings,
         string memory tokenName,
         string memory tokenSymbol
@@ -55,6 +56,7 @@ contract PermissionedPool is Pool {
             poolAdmin,
             serviceConfiguration,
             withdrawController,
+            poolController,
             poolSettings,
             tokenName,
             tokenSymbol

--- a/contracts/permissioned/PermissionedPoolFactory.sol
+++ b/contracts/permissioned/PermissionedPoolFactory.sol
@@ -1,23 +1,21 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.16;
 
-import "./interfaces/IPoolAdminAccessControl.sol";
+// import "./interfaces/IPoolAdminAccessControl.sol";
 import "./interfaces/IPermissionedServiceConfiguration.sol";
-import "../PoolFactory.sol";
+import "../interfaces/IPoolFactory.sol";
 import "./PermissionedPool.sol";
 
 /**
  * @title PermissionedPoolFactory
  */
-contract PermissionedPoolFactory is PoolFactory {
+contract PermissionedPoolFactory is IPoolFactory {
     /**
-     * @dev Reference to the PermissionedServiceConfiguration contract
+     * @dev Reference to the ServiceConfiguration contract
      */
     address private _serviceConfiguration;
 
-    constructor(address serviceConfiguration)
-        PoolFactory(serviceConfiguration)
-    {
+    constructor(address serviceConfiguration) {
         _serviceConfiguration = serviceConfiguration;
     }
 
@@ -35,11 +33,12 @@ contract PermissionedPoolFactory is PoolFactory {
     }
 
     /**
-     * @inheritdoc PoolFactory
+     * @inheritdoc IPoolFactory
      */
     function createPool(
         address liquidityAsset,
         address withdrawControllerFactory,
+        address poolControllerFactory,
         IPoolConfigurableSettings calldata settings
     ) public override onlyVerifiedPoolAdmin returns (address poolAddress) {
         require(
@@ -52,6 +51,7 @@ contract PermissionedPoolFactory is PoolFactory {
             msg.sender,
             address(_serviceConfiguration),
             withdrawControllerFactory,
+            poolControllerFactory,
             settings,
             "PerimeterPoolToken",
             "PPT"

--- a/test/PoolFactory.test.ts
+++ b/test/PoolFactory.test.ts
@@ -2,7 +2,11 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { deployMockERC20 } from "./support/erc20";
-import { DEFAULT_POOL_SETTINGS } from "./support/pool";
+import {
+  DEFAULT_POOL_SETTINGS,
+  deployPoolControllerFactory,
+  deployWithdrawControllerFactory
+} from "./support/pool";
 
 describe("PoolFactory", () => {
   async function deployFixture() {
@@ -31,29 +35,31 @@ describe("PoolFactory", () => {
     const poolFactory = await PoolFactory.deploy(serviceConfiguration.address);
     await poolFactory.deployed();
 
-    const WithdrawControllerFactory = await ethers.getContractFactory(
-      "WithdrawControllerFactory",
-      {
-        libraries: {
-          PoolLib: poolLib.address
-        }
-      }
-    );
-    const withdrawControllerFactory = await WithdrawControllerFactory.deploy(
+    const withdrawControllerFactory = await deployWithdrawControllerFactory(
+      poolLib.address,
       serviceConfiguration.address
     );
-    await withdrawControllerFactory.deployed();
+
+    const poolControllerFactory = await deployPoolControllerFactory(
+      poolLib.address,
+      serviceConfiguration.address
+    );
 
     return {
       poolFactory,
       liquidityAsset,
-      withdrawControllerFactory
+      withdrawControllerFactory,
+      poolControllerFactory
     };
   }
 
   it("reverts if given a zero withdraw window", async () => {
-    const { poolFactory, withdrawControllerFactory, liquidityAsset } =
-      await loadFixture(deployFixture);
+    const {
+      poolFactory,
+      withdrawControllerFactory,
+      poolControllerFactory,
+      liquidityAsset
+    } = await loadFixture(deployFixture);
 
     const poolSettings = Object.assign({}, DEFAULT_POOL_SETTINGS, {
       withdrawRequestPeriodDuration: 0
@@ -62,13 +68,15 @@ describe("PoolFactory", () => {
       poolFactory.createPool(
         liquidityAsset.address,
         withdrawControllerFactory.address,
+        poolControllerFactory.address,
         poolSettings
       )
     ).to.be.revertedWith("PoolFactory: Invalid duration");
   });
 
   it("reverts if given an invalid pool withdraw controller factory", async () => {
-    const { poolFactory, liquidityAsset } = await loadFixture(deployFixture);
+    const { poolFactory, poolControllerFactory, liquidityAsset } =
+      await loadFixture(deployFixture);
 
     const poolSettings = Object.assign({}, DEFAULT_POOL_SETTINGS, {
       withdrawRequestPeriodDuration: 0
@@ -77,19 +85,42 @@ describe("PoolFactory", () => {
       poolFactory.createPool(
         /* liquidityAsset */ liquidityAsset.address,
         "0x0000000000000000000000000000000000000000",
+        poolControllerFactory.address,
+        poolSettings
+      )
+    ).to.be.revertedWith("PoolFactory: Invalid duration");
+  });
+
+  it("reverts if given an invalid pool admin controller factory", async () => {
+    const { poolFactory, withdrawControllerFactory, liquidityAsset } =
+      await loadFixture(deployFixture);
+
+    const poolSettings = Object.assign({}, DEFAULT_POOL_SETTINGS, {
+      withdrawRequestPeriodDuration: 0
+    });
+    await expect(
+      poolFactory.createPool(
+        /* liquidityAsset */ liquidityAsset.address,
+        withdrawControllerFactory.address,
+        "0x0000000000000000000000000000000000000000",
         poolSettings
       )
     ).to.be.revertedWith("PoolFactory: Invalid duration");
   });
 
   it("emits PoolCreated", async () => {
-    const { poolFactory, liquidityAsset, withdrawControllerFactory } =
-      await loadFixture(deployFixture);
+    const {
+      poolFactory,
+      liquidityAsset,
+      withdrawControllerFactory,
+      poolControllerFactory
+    } = await loadFixture(deployFixture);
 
     await expect(
       poolFactory.createPool(
         /* liquidityAsset */ liquidityAsset.address,
         withdrawControllerFactory.address,
+        poolControllerFactory.address,
         DEFAULT_POOL_SETTINGS
       )
     ).to.emit(poolFactory, "PoolCreated");

--- a/test/controllers/PoolController.test.ts
+++ b/test/controllers/PoolController.test.ts
@@ -1,0 +1,387 @@
+import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { collateralizeLoan, deployLoan, fundLoan } from "../support/loan";
+import { activatePool, deployPool, depositToPool } from "../support/pool";
+
+describe("PoolController", () => {
+  async function loadPoolFixture() {
+    const [operator, poolAdmin, borrower, otherAccount, ...otherAccounts] =
+      await ethers.getSigners();
+
+    const { pool, liquidityAsset, poolController, serviceConfiguration } =
+      await deployPool({
+        operator,
+        poolAdmin: poolAdmin
+      });
+
+    const { loan } = await deployLoan(
+      pool.address,
+      borrower.address,
+      liquidityAsset.address,
+      serviceConfiguration
+    );
+
+    return {
+      operator,
+      poolAdmin,
+      borrower,
+      otherAccount,
+      otherAccounts,
+      pool,
+      loan,
+      liquidityAsset,
+      poolController
+    };
+  }
+
+  describe("setRequestFee()", () => {
+    it("sets the request fee in Bps", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      const originalSettings = await poolController.settings();
+      expect(originalSettings.requestFeeBps).to.equal(500);
+
+      await poolController.connect(poolAdmin).setRequestFee(1000);
+
+      const settings = await poolController.settings();
+      expect(settings.requestFeeBps).to.equal(1000);
+    });
+
+    it("does not let anyone except the admin to set the fee", async () => {
+      const { poolController, otherAccount } = await loadFixture(
+        loadPoolFixture
+      );
+
+      const originalSettings = await poolController.settings();
+      expect(originalSettings.requestFeeBps).to.equal(500);
+
+      await expect(
+        poolController.connect(otherAccount).setRequestFee(10)
+      ).to.be.revertedWith("Pool: caller is not admin");
+    });
+
+    it("does not allow setting the request fee once the pool is active", async () => {
+      const { pool, poolController, poolAdmin, liquidityAsset } =
+        await loadFixture(loadPoolFixture);
+
+      const originalSettings = await poolController.settings();
+      expect(originalSettings.requestFeeBps).to.equal(500);
+
+      await activatePool(pool, poolAdmin, liquidityAsset);
+
+      await expect(
+        poolController.connect(poolAdmin).setRequestFee(10)
+      ).to.be.revertedWith("Pool: FunctionInvalidAtThisLifeCycleState");
+    });
+  });
+
+  describe("requestFee()", () => {
+    it("returns the number of shares that will be charged to make this request", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      await poolController.connect(poolAdmin).setRequestFee(500); // 5%
+
+      expect(await poolController.requestFee(1_000)).to.equal(50);
+    });
+  });
+
+  describe("setWithdrawGate()", () => {
+    it("sets the withdraw gate in Bps", async () => {
+      const { pool, poolController, poolAdmin, liquidityAsset } =
+        await loadFixture(loadPoolFixture);
+      await activatePool(pool, poolAdmin, liquidityAsset);
+
+      const originalSettings = await poolController.settings();
+      expect(originalSettings.withdrawGateBps).to.equal(10_000);
+
+      await poolController.connect(poolAdmin).setWithdrawGate(10);
+
+      const settings = await poolController.settings();
+      expect(settings.withdrawGateBps).to.equal(10);
+    });
+
+    it("does not let anyone except the admin to set the withdraw gate", async () => {
+      const { poolController, otherAccount } = await loadFixture(
+        loadPoolFixture
+      );
+
+      const originalSettings = await poolController.settings();
+      expect(originalSettings.withdrawGateBps).to.equal(10_000);
+
+      await expect(
+        poolController.connect(otherAccount).setWithdrawGate(10)
+      ).to.be.revertedWith("Pool: caller is not admin");
+    });
+
+    it("does not allow setting the request fee if the pool is paused", async () => {
+      // TODO: Pause pool
+    });
+  });
+
+  describe("withdrawGate()", () => {
+    it("returns the current withdraw gate", async () => {
+      const { poolController } = await loadFixture(loadPoolFixture);
+
+      expect(await poolController.withdrawGate()).to.equal(10_000);
+    });
+
+    it("returns 100% if the pool is closed", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      await poolController.connect(poolAdmin).setWithdrawGate(0);
+
+      expect(await poolController.withdrawGate()).to.equal(0);
+
+      // TODO: Close Pool
+      // expect(await pool.withdrawGate()).to.equal(10_000);
+    });
+  });
+
+  describe("setPoolCapacity()", () => {
+    it("prevents setting capacity to less than current pool size", async () => {
+      const { pool, poolController, otherAccount, poolAdmin, liquidityAsset } =
+        await loadFixture(loadPoolFixture);
+
+      await activatePool(pool, poolAdmin, liquidityAsset);
+      await depositToPool(pool, otherAccount, liquidityAsset, 100);
+      await expect(
+        poolController.connect(poolAdmin).setPoolCapacity(1)
+      ).to.be.revertedWith("Pool: invalid capacity");
+    });
+
+    it("allows setting pool capacity", async () => {
+      const { pool, poolController, otherAccount, poolAdmin, liquidityAsset } =
+        await loadFixture(loadPoolFixture);
+
+      await activatePool(pool, poolAdmin, liquidityAsset);
+      await depositToPool(pool, otherAccount, liquidityAsset, 100);
+      await expect(
+        poolController.connect(poolAdmin).setPoolCapacity(101)
+      ).to.emit(poolController, "PoolSettingsUpdated");
+
+      expect((await poolController.settings()).maxCapacity).to.equal(101);
+    });
+
+    it("reverts if not called by Pool Admin", async () => {
+      const { poolController, otherAccount } = await loadFixture(
+        loadPoolFixture
+      );
+
+      await expect(
+        poolController.connect(otherAccount).setPoolCapacity(1)
+      ).to.be.revertedWith("Pool: caller is not admin");
+    });
+  });
+
+  describe("setPoolEndDate()", () => {
+    it("reverts if trying to move up end date", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      const newEndDate = (await poolController.settings()).endDate.add(1);
+
+      await expect(
+        poolController.connect(poolAdmin).setPoolEndDate(newEndDate)
+      ).to.be.revertedWith("Pool: can't move end date up");
+    });
+
+    it("reverts if trying to set end date to be in the past", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      const now = time.latest();
+
+      await expect(
+        poolController.connect(poolAdmin).setPoolEndDate(now)
+      ).to.be.revertedWith("Pool: can't move end date into the past");
+    });
+
+    it("allows moving up the pool end date", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      const newEndDate = (await poolController.settings()).endDate.sub(1);
+
+      await expect(
+        poolController.connect(poolAdmin).setPoolEndDate(newEndDate)
+      ).to.emit(poolController, "PoolSettingsUpdated");
+
+      expect((await poolController.settings()).endDate).to.equal(newEndDate);
+    });
+
+    it("reverts if not called by Pool Admin", async () => {
+      const { poolController, otherAccount } = await loadFixture(
+        loadPoolFixture
+      );
+
+      await expect(
+        poolController.connect(otherAccount).setPoolEndDate(1)
+      ).to.be.revertedWith("Pool: caller is not admin");
+    });
+  });
+
+  describe("state()", () => {
+    it("is closed when pool end date passes", async () => {
+      const { poolController } = await loadFixture(loadPoolFixture);
+
+      expect(await poolController.state()).to.equal(0); // initialized
+
+      const poolEndDate = (await poolController.settings()).endDate;
+      await time.increaseTo(poolEndDate);
+
+      expect(await poolController.state()).to.equal(3); // closed
+    });
+  });
+  describe("depositFirstLoss()", async () => {
+    it("first loss can be deposited and transitions lifecycle state", async () => {
+      const { pool, poolController, poolAdmin, liquidityAsset } =
+        await loadFixture(loadPoolFixture);
+
+      const { firstLossInitialMinimum: firstLossAmount } =
+        await poolController.settings();
+
+      // Grant allowance
+      await liquidityAsset
+        .connect(poolAdmin)
+        .approve(pool.address, firstLossAmount);
+
+      // Contribute first loss
+      expect(
+        await poolController
+          .connect(poolAdmin)
+          .depositFirstLoss(firstLossAmount, poolAdmin.address)
+      ).to.emit(poolController, "FirstLossDeposited");
+
+      // Check balance
+      expect(await pool.firstLoss()).to.equal(firstLossAmount);
+
+      // Check lifecycle
+      expect(await poolController.state()).to.equal(1); // Enum values are treated as ints
+    });
+
+    it("reverts if not called by Pool Admin", async () => {
+      const { poolController, otherAccount } = await loadFixture(
+        loadPoolFixture
+      );
+
+      await expect(
+        poolController
+          .connect(otherAccount)
+          .depositFirstLoss(100, otherAccount.address)
+      ).to.be.revertedWith("Pool: caller is not admin");
+    });
+  });
+
+  describe("withdrawFirstLoss()", async () => {
+    it("reverts if pool is not closed", async () => {
+      const { poolController, poolAdmin } = await loadFixture(loadPoolFixture);
+
+      await expect(
+        poolController
+          .connect(poolAdmin)
+          .withdrawFirstLoss(10, poolAdmin.address)
+      ).to.be.revertedWith("Pool: FunctionInvalidAtThisLifeCycleState");
+    });
+
+    it("reverts if pool is closed, but there are still active loans", async () => {
+      const {
+        pool,
+        poolController,
+        poolAdmin,
+        borrower,
+        loan,
+        otherAccount,
+        liquidityAsset
+      } = await loadFixture(loadPoolFixture);
+
+      await activatePool(pool, poolAdmin, liquidityAsset);
+      await depositToPool(
+        pool,
+        otherAccount,
+        liquidityAsset,
+        await loan.principal()
+      );
+      await collateralizeLoan(loan, borrower, liquidityAsset);
+      await fundLoan(loan, pool, poolAdmin);
+      await loan.connect(borrower).drawdown(await loan.principal());
+
+      // Fast forward past pool close
+      await time.increaseTo((await pool.settings()).endDate);
+      expect(await poolController.state()).to.equal(3); // Closed
+
+      await expect(
+        poolController
+          .connect(poolAdmin)
+          .withdrawFirstLoss(10, poolAdmin.address)
+      ).to.be.revertedWith("Pool: loans still active");
+    });
+
+    it("can withdraw first loss to a receiver", async () => {
+      const {
+        pool,
+        poolController,
+        poolAdmin,
+        borrower,
+        loan,
+        otherAccount,
+        liquidityAsset
+      } = await loadFixture(loadPoolFixture);
+
+      await activatePool(pool, poolAdmin, liquidityAsset);
+      await depositToPool(
+        pool,
+        otherAccount,
+        liquidityAsset,
+        await loan.principal()
+      );
+      await collateralizeLoan(loan, borrower, liquidityAsset);
+      await fundLoan(loan, pool, poolAdmin);
+      await loan.connect(borrower).drawdown(await loan.principal());
+
+      // Pay down loan
+      // Give borrower arbitrary amount to fully paydown loan
+      const borrowerExcessAmount = (await loan.principal()).mul(2);
+      await liquidityAsset.mint(borrower.address, borrowerExcessAmount);
+      await liquidityAsset
+        .connect(borrower)
+        .approve(loan.address, borrowerExcessAmount);
+      await loan.connect(borrower).completeFullPayment();
+
+      // Fast forward to pool enddate
+      await time.increaseTo(await (await pool.settings()).endDate);
+
+      // First loss available
+      const firstLossAmt = await pool.firstLoss();
+      const firstLossVault = await pool.firstLossVault();
+      const txn = await poolController
+        .connect(poolAdmin)
+        .withdrawFirstLoss(firstLossAmt, poolAdmin.address);
+      await txn.wait();
+
+      expect(txn)
+        .to.emit(poolController, "FirstLossWithdrawn")
+        .withArgs(poolAdmin.address, poolAdmin.address, firstLossAmt);
+
+      await expect(txn).to.changeTokenBalance(
+        liquidityAsset,
+        poolAdmin.address,
+        +firstLossAmt
+      );
+      await expect(txn).to.changeTokenBalance(
+        liquidityAsset,
+        firstLossVault,
+        -firstLossAmt
+      );
+    });
+
+    it("reverts if not called by Pool Admin", async () => {
+      const { poolController, otherAccount } = await loadFixture(
+        loadPoolFixture
+      );
+
+      await expect(
+        poolController
+          .connect(otherAccount)
+          .withdrawFirstLoss(100, otherAccount.address)
+      ).to.be.revertedWith("Pool: caller is not admin");
+    });
+  });
+});

--- a/test/libraries/PoolLib.test.ts
+++ b/test/libraries/PoolLib.test.ts
@@ -109,11 +109,6 @@ describe("PoolLib", () => {
             0
           )
       ).to.emit(poolLibWrapper, "FirstLossDeposited");
-
-      // Check balance of vault
-      expect(await liquidityAsset.balanceOf(firstLossVault.address)).to.equal(
-        FIRST_LOSS_AMOUNT
-      );
     });
 
     it("transfers liquidity to vault from a supplier", async () => {
@@ -149,11 +144,6 @@ describe("PoolLib", () => {
             0
           )
       ).to.emit(poolLibWrapper, "FirstLossDeposited");
-
-      // Check balance of vault
-      expect(await liquidityAsset.balanceOf(firstLossVault.address)).to.equal(
-        FIRST_LOSS_AMOUNT
-      );
     });
 
     it("graduates PoolLifeCycleState if threshold is met, and initial state is Initialized", async () => {
@@ -214,11 +204,6 @@ describe("PoolLib", () => {
       const withdrawAmount = 1000;
       await liquidityAsset.mint(firstLossVault.address, withdrawAmount);
 
-      // Check balance prior
-      const receiverBalancePrior = await liquidityAsset.balanceOf(
-        otherAccount.address
-      );
-
       expect(
         await poolLibWrapper.executeFirstLossWithdraw(
           withdrawAmount,
@@ -226,11 +211,6 @@ describe("PoolLib", () => {
           firstLossVault.address
         )
       ).to.emit(poolLibWrapper, "FirstLossWithdrawal");
-
-      // Check balance after
-      expect(await liquidityAsset.balanceOf(otherAccount.address)).to.equal(
-        receiverBalancePrior.add(withdrawAmount)
-      );
     });
   });
 

--- a/test/scenarios/business/2.test.ts
+++ b/test/scenarios/business/2.test.ts
@@ -65,7 +65,7 @@ describe("Business Scenario 2", () => {
 
     // activate pool
     await activatePool(pool, poolAdmin, mockUSDC);
-    const startTime = (await pool.poolActivatedAt()).toNumber();
+    const startTime = (await pool.activatedAt()).toNumber();
 
     // Mint for lenders
     await mockUSDC.mint(lenderA.address, INPUTS.lenderADepositAmount);

--- a/test/scenarios/business/3.test.ts
+++ b/test/scenarios/business/3.test.ts
@@ -63,7 +63,7 @@ describe("Business Scenario 3", () => {
 
     // activate pool
     await activatePool(pool, poolManager, mockUSDC);
-    const startTime = (await pool.poolActivatedAt()).toNumber();
+    const startTime = (await pool.activatedAt()).toNumber();
 
     // Mint for lenders
     await mockUSDC.mint(lenderA.address, INPUTS.lenderADepositAmount);

--- a/test/scenarios/pool/withdraw-request.test.ts
+++ b/test/scenarios/pool/withdraw-request.test.ts
@@ -7,16 +7,17 @@ describe("Withdraw Requests", () => {
   async function loadPoolFixture() {
     const [operator, poolAdmin, aliceLender, bobLender] =
       await ethers.getSigners();
-    const { pool, liquidityAsset } = await deployPool({
-      operator,
-      poolAdmin: poolAdmin
-    });
+    const { pool, liquidityAsset, poolController, withdrawController } =
+      await deployPool({
+        operator,
+        poolAdmin: poolAdmin
+      });
 
     // Set the request fee to 10%
-    await pool.connect(poolAdmin).setRequestFee(1000);
+    await poolController.connect(poolAdmin).setRequestFee(1000);
 
     // Set the withdraw gate to 25%
-    await pool.connect(poolAdmin).setWithdrawGate(2500);
+    await poolController.connect(poolAdmin).setWithdrawGate(2500);
 
     // activate the pool
     await activatePool(pool, poolAdmin, liquidityAsset);
@@ -26,11 +27,6 @@ describe("Withdraw Requests", () => {
 
     // deposit 70 tokens from Bob
     await depositToPool(pool, bobLender, liquidityAsset, 70);
-
-    const withdrawController = await ethers.getContractAt(
-      "WithdrawController",
-      await pool.withdrawController()
-    );
 
     return {
       pool,


### PR DESCRIPTION
There's still a few more methods to move (I don't want any reference to Admin in the Pool itself), but this gets the process started by moving all `state` (lifeCycleState) methods, the `settings`, and the FirstLoss logic over to the PoolController.  

Still has to call back into the Pool to actually transfer from the FirstLoss vault, which I may change to keep it completely separate.


```
 ·------------------------------------|--------------|----------------·
 |  Contract Name                     ·  Size (KiB)  ·  Change (KiB)  │
 ·····································|··············|·················
 |  Pool                              ·      13.960  ·        -0.381  │
 ·····································|··············|·················
 |  PermissionedPool                  ·      14.400  ·        -0.358  │
 ·····································|··············|·················
 |  LoanFactory                       ·      17.378  ·                │
 ·····································|··············|·················
 |  PermissionedLoanFactory           ·      18.181  ·                │
 ·····································|··············|·················
 |  PoolFactory                       ·      20.989  ·        -0.558  │
 ·····································|··············|·················
 |  PermissionedPoolFactory           ·      27.054  ·        -0.542  │
 ·------------------------------------|--------------|----------------·
```