### PR TITLE
VAL-87 Soften requirement on Collateralized loan state

### DIFF
--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -232,6 +232,7 @@ contract Loan is ILoan {
         onlyNonTerminalState
         returns (ILoanLifeCycleState)
     {
+        require(amount > 0, "Loan: posting 0 collateral");
         _state = LoanLib.postFungibleCollateral(
             address(_collateralVault),
             asset,

--- a/test/Loan.test.ts
+++ b/test/Loan.test.ts
@@ -685,6 +685,18 @@ describe("Loan", () => {
         loan.connect(other).postFungibleCollateral(collateralAsset.address, 100)
       ).to.be.revertedWith("Loan: caller is not borrower");
     });
+
+    it("disallows passing 0 collateral", async () => {
+      const fixture = await loadFixture(deployFixture);
+      const { borrower, loan, collateralAsset } = fixture;
+
+      // Post collateral
+      await expect(
+        loan
+          .connect(borrower)
+          .postFungibleCollateral(collateralAsset.address, 0)
+      ).to.be.revertedWith("Loan: posting 0 collateral");
+    });
   });
 
   describe("postNonFungibleCollateral", () => {

--- a/test/permissioned/PermissionedLoan.test.ts
+++ b/test/permissioned/PermissionedLoan.test.ts
@@ -101,8 +101,10 @@ describe("PermissionedLoan", () => {
         .connect(poolAdmin)
         .allowParticipant(borrower.address);
 
+      await liquidityAsset.mint(borrower.address, 1);
+      await liquidityAsset.connect(borrower).approve(loan.address, 1);
       await expect(
-        loan.connect(borrower).postFungibleCollateral(liquidityAsset.address, 0)
+        loan.connect(borrower).postFungibleCollateral(liquidityAsset.address, 1)
       ).to.emit(loan, "PostedCollateral");
     });
   });

--- a/test/scenarios/business/1.test.ts
+++ b/test/scenarios/business/1.test.ts
@@ -2,7 +2,7 @@ import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { deployPool, activatePool } from "../../support/pool";
-import { collateralizeLoan, deployLoan, fundLoan } from "../../support/loan";
+import { deployLoan, fundLoan } from "../../support/loan";
 import { deployMockERC20 } from "../../support/erc20";
 
 describe("Business Scenario 1", () => {
@@ -111,9 +111,6 @@ describe("Business Scenario 1", () => {
     );
     // mint USDC for borrower to pay down loanTwo
     await mockUSDC.mint(borrowerTwo.address, INPUTS.loanTwoPayment);
-
-    await collateralizeLoan(loanOne, borrowerOne, mockUSDC, 0);
-    await collateralizeLoan(loanTwo, borrowerTwo, mockUSDC, 0);
 
     return {
       startTime,

--- a/test/scenarios/business/2.test.ts
+++ b/test/scenarios/business/2.test.ts
@@ -2,7 +2,7 @@ import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { deployPool, activatePool } from "../../support/pool";
-import { collateralizeLoan, deployLoan, fundLoan } from "../../support/loan";
+import { deployLoan, fundLoan } from "../../support/loan";
 import { deployMockERC20 } from "../../support/erc20";
 
 describe("Business Scenario 2", () => {
@@ -89,9 +89,6 @@ describe("Business Scenario 2", () => {
     );
     // mint USDC for borrower to pay down loanOne
     await mockUSDC.mint(borrower.address, INPUTS.loanPayment);
-
-    // Collateralize loan
-    await collateralizeLoan(loan, borrower, mockUSDC, 0);
 
     return {
       startTime,

--- a/test/scenarios/business/3.test.ts
+++ b/test/scenarios/business/3.test.ts
@@ -88,9 +88,6 @@ describe("Business Scenario 3", () => {
     // mint USDC for borrower to pay down loanOne
     await mockUSDC.mint(borrower.address, INPUTS.loanPayment);
 
-    // Collateralize loan
-    await collateralizeLoan(loan, borrower, mockUSDC, 0);
-
     return {
       startTime,
       pool,


### PR DESCRIPTION
Rather than removing this state, I just enabled funding loans in a `Requested` state. I also took this as an opportunity to limit posting fungible collateral with zero amounts...which was our silly hack for zero-collateralized loans. I think this is more explicit now. 

I also updated Lucid to reflect these changes, which was maybe slightly premature: https://lucid.app/lucidchart/73eda3a3-3de1-4f53-9007-7752dea91956/edit?page=0_0&invitationId=inv_393fa28f-3f57-49f3-9ba5-689196b4167a#