### PR TITLE
VAL-91 (cont.) Prevent deploying capital to new loans unless it exists in the pool

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -210,7 +210,7 @@ contract Pool is IPool, ERC20 {
         ILoan loan = ILoan(addr);
         uint256 principal = loan.principal();
 
-        require(totalAvailableAssets() >= principal, "Pool: not enough assets");
+        require(liquidityPoolAssets() >= principal, "Pool: not enough assets");
 
         _liquidityAsset.safeApprove(addr, principal);
         loan.fund();
@@ -301,9 +301,11 @@ contract Pool is IPool, ERC20 {
      *
      * Note: This is equivalent of EIP-4626 `maxRedeem`
      */
-    function maxRedeemRequest(
-        address owner
-    ) public view returns (uint256 maxShares) {
+    function maxRedeemRequest(address owner)
+        public
+        view
+        returns (uint256 maxShares)
+    {
         maxShares = withdrawController.maxRedeemRequest(owner);
     }
 
@@ -314,9 +316,11 @@ contract Pool is IPool, ERC20 {
      *
      * Note: This is equivalent of EIP-4626 `maxWithdraw`
      */
-    function maxWithdrawRequest(
-        address owner
-    ) public view returns (uint256 maxAssets) {
+    function maxWithdrawRequest(address owner)
+        public
+        view
+        returns (uint256 maxAssets)
+    {
         maxAssets = convertToAssets(maxRedeemRequest(owner));
     }
 
@@ -327,9 +331,11 @@ contract Pool is IPool, ERC20 {
      *
      * Note: This is equivalent of EIP-4626 `previewRedeem`
      */
-    function previewRedeemRequest(
-        uint256 shares
-    ) external view returns (uint256 assets) {
+    function previewRedeemRequest(uint256 shares)
+        external
+        view
+        returns (uint256 assets)
+    {
         assets = withdrawController.previewRedeemRequest(shares);
     }
 
@@ -340,18 +346,23 @@ contract Pool is IPool, ERC20 {
      *
      * Note: This is equivalent of EIP-4626 `previewWithdraw`
      */
-    function previewWithdrawRequest(
-        uint256 assets
-    ) external view returns (uint256 shares) {
+    function previewWithdrawRequest(uint256 assets)
+        external
+        view
+        returns (uint256 shares)
+    {
         shares = withdrawController.previewWithdrawRequest(assets);
     }
 
     /**
      * @dev Request a redemption of a number of shares from the pool
      */
-    function requestRedeem(
-        uint256 shares
-    ) external onlyActivatedPool onlyLender returns (uint256 assets) {
+    function requestRedeem(uint256 shares)
+        external
+        onlyActivatedPool
+        onlyLender
+        returns (uint256 assets)
+    {
         assets = convertToAssets(shares);
         _performRedeemRequest(msg.sender, shares, assets);
     }
@@ -359,9 +370,12 @@ contract Pool is IPool, ERC20 {
     /**
      * @dev Request a Withdraw of a number of assets from the pool
      */
-    function requestWithdraw(
-        uint256 assets
-    ) external onlyActivatedPool onlyLender returns (uint256 shares) {
+    function requestWithdraw(uint256 assets)
+        external
+        onlyActivatedPool
+        onlyLender
+        returns (uint256 shares)
+    {
         shares = convertToShares(assets);
         _performRedeemRequest(msg.sender, shares, assets);
     }
@@ -393,9 +407,11 @@ contract Pool is IPool, ERC20 {
      *
      * Note: This is equivalent of EIP-4626 `maxRedeem`
      */
-    function maxRequestCancellation(
-        address owner
-    ) public view returns (uint256 maxShares) {
+    function maxRequestCancellation(address owner)
+        public
+        view
+        returns (uint256 maxShares)
+    {
         maxShares = withdrawController.maxRequestCancellation(owner);
     }
 
@@ -406,9 +422,12 @@ contract Pool is IPool, ERC20 {
      *
      * Emits a {WithdrawRequestCancelled} event.
      */
-    function cancelRedeemRequest(
-        uint256 shares
-    ) external onlyActivatedPool onlyLender returns (uint256 assets) {
+    function cancelRedeemRequest(uint256 shares)
+        external
+        onlyActivatedPool
+        onlyLender
+        returns (uint256 assets)
+    {
         assets = convertToAssets(shares);
         _performRequestCancellation(msg.sender, shares, assets);
     }
@@ -420,9 +439,12 @@ contract Pool is IPool, ERC20 {
      *
      * Emits a {WithdrawRequestCancelled} event.
      */
-    function cancelWithdrawRequest(
-        uint256 assets
-    ) external onlyActivatedPool onlyLender returns (uint256 shares) {
+    function cancelWithdrawRequest(uint256 assets)
+        external
+        onlyActivatedPool
+        onlyLender
+        returns (uint256 shares)
+    {
         shares = convertToShares(assets);
         _performRequestCancellation(msg.sender, shares, assets);
     }
@@ -484,9 +506,12 @@ contract Pool is IPool, ERC20 {
      * @dev Calculates the amount of shares that would be exchanged by the vault for the amount of assets provided.
      * Rounds DOWN per EIP4626.
      */
-    function convertToShares(
-        uint256 assets
-    ) public view override returns (uint256) {
+    function convertToShares(uint256 assets)
+        public
+        view
+        override
+        returns (uint256)
+    {
         return
             PoolLib.calculateConversion(
                 assets,
@@ -500,9 +525,12 @@ contract Pool is IPool, ERC20 {
      * @dev Calculates the amount of assets that would be exchanged by the vault for the amount of shares provided.
      * Rounds DOWN per EIP4626.
      */
-    function convertToAssets(
-        uint256 shares
-    ) public view override returns (uint256) {
+    function convertToAssets(uint256 shares)
+        public
+        view
+        override
+        returns (uint256)
+    {
         return
             PoolLib.calculateConversion(
                 shares,
@@ -515,9 +543,13 @@ contract Pool is IPool, ERC20 {
     /**
      * @dev Calculates the maximum amount of underlying assets that can be deposited in a single deposit call by the receiver.
      */
-    function maxDeposit(
-        address
-    ) public view virtual override returns (uint256) {
+    function maxDeposit(address)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return
             PoolLib.calculateMaxDeposit(
                 poolController.state(),
@@ -530,9 +562,12 @@ contract Pool is IPool, ERC20 {
      * @dev Allows users to simulate the effects of their deposit at the current block.
      * Rounds DOWN per EIP4626
      */
-    function previewDeposit(
-        uint256 assets
-    ) public view override returns (uint256) {
+    function previewDeposit(uint256 assets)
+        public
+        view
+        override
+        returns (uint256)
+    {
         return
             PoolLib.calculateConversion(
                 assets,
@@ -547,10 +582,7 @@ contract Pool is IPool, ERC20 {
      * @dev Deposits assets of underlying tokens into the vault and grants ownership of shares to receiver.
      * Emits a {Deposit} event.
      */
-    function deposit(
-        uint256 assets,
-        address receiver
-    )
+    function deposit(uint256 assets, address receiver)
         public
         virtual
         override
@@ -571,9 +603,13 @@ contract Pool is IPool, ERC20 {
     /**
      * @dev Returns the maximum amount of shares that can be minted in a single mint call by the receiver.
      */
-    function maxMint(
-        address receiver
-    ) public view virtual override returns (uint256) {
+    function maxMint(address receiver)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return previewDeposit(maxDeposit(receiver));
     }
 
@@ -581,9 +617,12 @@ contract Pool is IPool, ERC20 {
      * @dev Allows users to simulate the effects of their mint at the current block.
      * Rounds UP per EIP4626, to determine the number of assets to be provided for shares.
      */
-    function previewMint(
-        uint256 shares
-    ) public view override returns (uint256 assets) {
+    function previewMint(uint256 shares)
+        public
+        view
+        override
+        returns (uint256 assets)
+    {
         return
             PoolLib.calculateConversion(
                 shares,
@@ -598,10 +637,7 @@ contract Pool is IPool, ERC20 {
      * @dev Mints exactly shares vault shares to receiver by depositing assets of underlying tokens.
      * Emits a {Deposit} event.
      */
-    function mint(
-        uint256 shares,
-        address receiver
-    )
+    function mint(uint256 shares, address receiver)
         public
         virtual
         override
@@ -623,9 +659,12 @@ contract Pool is IPool, ERC20 {
     /**
      * @dev Returns the maximum amount of underlying assets that can be withdrawn from the owner balance with a single withdraw call.
      */
-    function maxWithdraw(
-        address owner
-    ) public view override returns (uint256 assets) {
+    function maxWithdraw(address owner)
+        public
+        view
+        override
+        returns (uint256 assets)
+    {
         assets = withdrawController.maxWithdraw(owner);
     }
 
@@ -633,9 +672,12 @@ contract Pool is IPool, ERC20 {
      * @dev Simulate the effects of their withdrawal at the current block.
      * Per EIP4626, should round UP on the number of shares required for assets.
      */
-    function previewWithdraw(
-        uint256 assets
-    ) external view override returns (uint256 shares) {
+    function previewWithdraw(uint256 assets)
+        external
+        view
+        override
+        returns (uint256 shares)
+    {
         shares = withdrawController.previewWithdraw(msg.sender, assets);
     }
 
@@ -665,9 +707,12 @@ contract Pool is IPool, ERC20 {
      * @dev The maximum amount of shares that can be redeemed from the owner
      * balance through a redeem call.
      */
-    function maxRedeem(
-        address owner
-    ) public view override returns (uint256 maxShares) {
+    function maxRedeem(address owner)
+        public
+        view
+        override
+        returns (uint256 maxShares)
+    {
         maxShares = withdrawController.maxRedeem(owner);
     }
 
@@ -675,9 +720,12 @@ contract Pool is IPool, ERC20 {
      * @dev Simulates the effects of their redeemption at the current block.
      * Per EIP4626, should round DOWN.
      */
-    function previewRedeem(
-        uint256 shares
-    ) external view override returns (uint256 assets) {
+    function previewRedeem(uint256 shares)
+        external
+        view
+        override
+        returns (uint256 assets)
+    {
         assets = withdrawController.previewRedeem(msg.sender, shares);
     }
 

--- a/test/Pool.test.ts
+++ b/test/Pool.test.ts
@@ -26,13 +26,6 @@ describe("Pool", () => {
       serviceConfiguration
     );
 
-    const { loan: loanTwo } = await deployLoan(
-      pool.address,
-      borrower.address,
-      liquidityAsset.address,
-      serviceConfiguration
-    );
-
     return {
       pool,
       poolController,
@@ -42,7 +35,6 @@ describe("Pool", () => {
       borrower,
       otherAccount,
       loan,
-      loanTwo,
       otherAccounts
     };
   }


### PR DESCRIPTION
A previous attempt at addressing this was incomplete: https://github.com/circlefin/valyria-core/pull/82

Specifically, it checked against `totalAvailableAssets()`, which includes assets deployed to loans. What we want is `liquidityPoolAssets`, which is the free-floating, available assets in the liquidity reserve. 