### PR TITLE
Move PoolController,WithdrawController factory definitions to PoolFactory constructor

### DIFF
--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -14,8 +14,24 @@ contract PoolFactory is IPoolFactory {
      */
     address private _serviceConfiguration;
 
-    constructor(address serviceConfiguration) {
+    /**
+     * @dev Reference to the WithdrawControllerFactory contract
+     */
+    address private _withdrawControllerFactory;
+
+    /**
+     * @dev Reference to the PoolControllerFactory contract
+     */
+    address private _poolControllerFactory;
+
+    constructor(
+        address serviceConfiguration,
+        address withdrawControllerFactory,
+        address poolControllerFactory
+    ) {
         _serviceConfiguration = serviceConfiguration;
+        _withdrawControllerFactory = withdrawControllerFactory;
+        _poolControllerFactory = poolControllerFactory;
     }
 
     /**
@@ -24,8 +40,6 @@ contract PoolFactory is IPoolFactory {
      */
     function createPool(
         address liquidityAsset,
-        address withdrawControllerFactory,
-        address poolControllerFactory,
         IPoolConfigurableSettings calldata settings
     ) public virtual returns (address poolAddress) {
         require(
@@ -35,11 +49,6 @@ contract PoolFactory is IPoolFactory {
         require(
             settings.withdrawRequestPeriodDuration > 0,
             "PoolFactory: Invalid duration"
-        );
-        require(
-            withdrawControllerFactory != address(0) &&
-                poolControllerFactory != address(0),
-            "PoolFactory: Invalid address"
         );
         if (settings.fixedFee > 0) {
             require(
@@ -53,8 +62,8 @@ contract PoolFactory is IPoolFactory {
             liquidityAsset,
             msg.sender,
             _serviceConfiguration,
-            withdrawControllerFactory,
-            poolControllerFactory,
+            _withdrawControllerFactory,
+            _poolControllerFactory,
             settings,
             "PerimeterPoolToken",
             "PPT"

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -16,10 +16,7 @@ interface IPoolFactory {
      * @dev Creates a pool's PoolAdmin controller
      * @dev Emits `PoolControllerCreated` event.
      */
-    function createPool(
-        address,
-        address,
-        address,
-        IPoolConfigurableSettings calldata
-    ) external returns (address);
+    function createPool(address, IPoolConfigurableSettings calldata)
+        external
+        returns (address);
 }

--- a/contracts/permissioned/PermissionedPoolFactory.sol
+++ b/contracts/permissioned/PermissionedPoolFactory.sol
@@ -20,9 +20,25 @@ contract PermissionedPoolFactory is IPoolFactory {
      */
     address private _poolAccessControlFactory;
 
-    constructor(address serviceConfiguration, address poolAccessControlFactory)
-    {
+    /**
+     * @dev Reference to the WithdrawControllerFactory contract
+     */
+    address private _withdrawControllerFactory;
+
+    /**
+     * @dev Reference to the PoolControllerFactory contract
+     */
+    address private _poolControllerFactory;
+
+    constructor(
+        address serviceConfiguration,
+        address withdrawControllerFactory,
+        address poolControllerFactory,
+        address poolAccessControlFactory
+    ) {
         _serviceConfiguration = serviceConfiguration;
+        _withdrawControllerFactory = withdrawControllerFactory;
+        _poolControllerFactory = poolControllerFactory;
         _poolAccessControlFactory = poolAccessControlFactory;
     }
 
@@ -44,8 +60,6 @@ contract PermissionedPoolFactory is IPoolFactory {
      */
     function createPool(
         address liquidityAsset,
-        address withdrawControllerFactory,
-        address poolControllerFactory,
         IPoolConfigurableSettings calldata settings
     ) public override onlyVerifiedPoolAdmin returns (address poolAddress) {
         require(
@@ -57,8 +71,8 @@ contract PermissionedPoolFactory is IPoolFactory {
             liquidityAsset,
             msg.sender,
             address(_serviceConfiguration),
-            withdrawControllerFactory,
-            poolControllerFactory,
+            _withdrawControllerFactory,
+            _poolControllerFactory,
             _poolAccessControlFactory,
             settings,
             "PerimeterPoolToken",


### PR DESCRIPTION
This ensures a Pool Admin can't mess around with different PoolControllers and WithdrawControllers 