### PR TITLE
Allow PAs to set cancellation fees

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -482,9 +482,10 @@ contract Pool is IPool, ERC20 {
             maxRequestCancellation(owner) >= shares,
             "Pool: InsufficientBalance"
         );
-        withdrawController.performRequestCancellation(owner, shares);
-        uint256 feeShares = (shares);
+        uint256 feeShares = poolController.requestCancellationFee(shares);
         _burn(owner, feeShares);
+        withdrawController.performRequestCancellation(owner, shares);
+
         emit WithdrawRequestCancelled(owner, assets, shares);
     }
 

--- a/contracts/controllers/PoolController.sol
+++ b/contracts/controllers/PoolController.sol
@@ -146,6 +146,31 @@ contract PoolController is IPoolController {
     /**
      * @inheritdoc IPoolController
      */
+    function setRequestCancellationFee(uint256 feeBps)
+        external
+        onlyAdmin
+        atState(IPoolLifeCycleState.Initialized)
+    {
+        _settings.requestCancellationFeeBps = feeBps;
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
+    function requestCancellationFee(uint256 sharesOrAssets)
+        public
+        view
+        returns (uint256 feeShares)
+    {
+        feeShares = PoolLib.calculateCancellationFee(
+            sharesOrAssets,
+            _settings.requestCancellationFeeBps
+        );
+    }
+
+    /**
+     * @inheritdoc IPoolController
+     */
     function setWithdrawGate(uint256 _withdrawGateBps)
         external
         onlyAdmin

--- a/contracts/controllers/interfaces/IPoolController.sol
+++ b/contracts/controllers/interfaces/IPoolController.sol
@@ -84,6 +84,18 @@ interface IPoolController {
     function requestFee(uint256) external view returns (uint256);
 
     /**
+     * @dev Allow the current pool admin to update the pool cancellation fees
+     * before the pool has been activated.
+     */
+    function setRequestCancellationFee(uint256) external;
+
+    /**
+     * @dev Returns the cancellation fee for a given withdrawal request at the
+     * current block. The fee is the number of shares that will be charged.
+     */
+    function requestCancellationFee(uint256) external view returns (uint256);
+
+    /**
      * @dev Allow the current pool admin to update the withdraw gate at any
      * time if the pool is Initialized or Active
      */

--- a/test/scenarios/pool/withdraw-request.test.ts
+++ b/test/scenarios/pool/withdraw-request.test.ts
@@ -156,7 +156,11 @@ describe("Withdraw Requests", () => {
     expect(await pool.maxRequestCancellation(bobLender.address)).to.equal(3);
 
     // Cancel Bob's request
+    const bobBalance = await pool.balanceOf(bobLender.address);
     expect(await pool.connect(bobLender).cancelRedeemRequest(3));
+
+    // Expect a fee to be paid
+    expect(await pool.balanceOf(bobLender.address)).to.equal(bobBalance.sub(1));
     expect(await pool.maxRequestCancellation(bobLender.address)).to.equal(0);
   });
 });


### PR DESCRIPTION
It appears the logic for burning fees was removed in a rebase/refactor.  This adds it back in to match the Request fees logic and allows PAs to update 