### PR TITLE
[No ticket] Rename functions for consistency

### DIFF
--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -300,7 +300,7 @@ contract Loan is ILoan {
         require(settings.loanType == ILoanType.Open);
 
         fundingVault.withdraw(amount, _pool);
-        IPool(_pool).notifyLoanPrincipalReturned(amount);
+        IPool(_pool).onLoanPrincipalReturned(amount);
 
         emit FundsReclaimed(amount, _pool);
     }
@@ -323,7 +323,7 @@ contract Loan is ILoan {
             _state
         );
         outstandingPrincipal += amount;
-        IPool(_pool).notifyLoanStateTransitioned();
+        IPool(_pool).onLoanStateTransitioned();
         return amount;
     }
 
@@ -449,12 +449,12 @@ contract Loan is ILoan {
                 _fees.latePaymentFee
             )
         );
-        IPool(_pool).notifyLoanPrincipalReturned(outstandingPrincipal);
+        IPool(_pool).onLoanPrincipalReturned(outstandingPrincipal);
 
         paymentsRemaining = 0;
         _state = ILoanLifeCycleState.Matured;
 
-        IPool(_pool).notifyLoanStateTransitioned();
+        IPool(_pool).onLoanStateTransitioned();
         return payment;
     }
 
@@ -469,7 +469,7 @@ contract Loan is ILoan {
         returns (ILoanLifeCycleState)
     {
         _state = ILoanLifeCycleState.Defaulted;
-        IPool(_pool).notifyLoanStateTransitioned();
+        IPool(_pool).onLoanStateTransitioned();
         emit LifeCycleStateTransition(_state);
         return _state;
     }

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -263,7 +263,7 @@ contract Pool is IPool, ERC20 {
     /**
      * @inheritdoc IPool
      */
-    function notifyLoanPrincipalReturned(uint256 amount) external {
+    function onLoanPrincipalReturned(uint256 amount) external {
         require(_fundedLoans[msg.sender], "Pool: not funded loan");
         _accountings.outstandingLoanPrincipals -= amount;
     }
@@ -271,7 +271,7 @@ contract Pool is IPool, ERC20 {
     /**
      * @inheritdoc IPool
      */
-    function notifyLoanStateTransitioned() external override {
+    function onLoanStateTransitioned() external override {
         require(_fundedLoans[msg.sender], "Pool: not funded loan");
 
         ILoanLifeCycleState loanState = ILoan(msg.sender).state();

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -165,12 +165,12 @@ interface IPool is IERC4626 {
      * @dev Called by a loan, it notifies the pool that the loan has returned
      * principal to the pool.
      */
-    function notifyLoanPrincipalReturned(uint256 amount) external;
+    function onLoanPrincipalReturned(uint256 amount) external;
 
     /**
      * @dev Called by a loan, it notifies the pool that the loan has transitioned stated.
      */
-    function notifyLoanStateTransitioned() external;
+    function onLoanStateTransitioned() external;
 
     /**
      * @dev Called by the Pool Controller, it transfers the fixed fee


### PR DESCRIPTION
This renames:
- notifyLoanStateTransition --> onLoanStateTransitioned 
- notifyLoanPrincipalReturned --> onLoanPrincipalReturned 

This is more consistent with existing the `onActivated` method in the Pool, and is common convention for this sort of hook. 