### PR TITLE
Change SPDX-License-Identifiers to MIT

### DIFF
--- a/contracts/CollateralVault.sol
+++ b/contracts/CollateralVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/FeeVault.sol
+++ b/contracts/FeeVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/FirstLossVault.sol
+++ b/contracts/FirstLossVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/FundingVault.sol
+++ b/contracts/FundingVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IServiceConfiguration.sol";

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/ILoan.sol";

--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./Pool.sol";

--- a/contracts/ServiceConfiguration.sol
+++ b/contracts/ServiceConfiguration.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";

--- a/contracts/controllers/PoolController.sol
+++ b/contracts/controllers/PoolController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../interfaces/IPool.sol";

--- a/contracts/controllers/WithdrawController.sol
+++ b/contracts/controllers/WithdrawController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../interfaces/IPool.sol";

--- a/contracts/controllers/interfaces/IPoolController.sol
+++ b/contracts/controllers/interfaces/IPoolController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../interfaces/IPool.sol";

--- a/contracts/controllers/interfaces/IWithdrawController.sol
+++ b/contracts/controllers/interfaces/IWithdrawController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/factories/PoolControllerFactory.sol
+++ b/contracts/factories/PoolControllerFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../controllers/PoolController.sol";

--- a/contracts/factories/WithdrawControllerFactory.sol
+++ b/contracts/factories/WithdrawControllerFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../controllers/WithdrawController.sol";

--- a/contracts/factories/interfaces/IPoolControllerFactory.sol
+++ b/contracts/factories/interfaces/IPoolControllerFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../interfaces/IPool.sol";

--- a/contracts/factories/interfaces/IWithdrawControllerFactory.sol
+++ b/contracts/factories/interfaces/IWithdrawControllerFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./IServiceConfiguration.sol";

--- a/contracts/interfaces/ILoanFactory.sol
+++ b/contracts/interfaces/ILoanFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../interfaces/ILoan.sol";

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./IERC4626.sol";

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../interfaces/IPool.sol";

--- a/contracts/interfaces/IServiceConfigurable.sol
+++ b/contracts/interfaces/IServiceConfigurable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/interfaces/IServiceConfiguration.sol
+++ b/contracts/interfaces/IServiceConfiguration.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/libraries/LoanLib.sol
+++ b/contracts/libraries/LoanLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/libraries/PoolLib.sol
+++ b/contracts/libraries/PoolLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/contracts/mocks/MockERC721.sol
+++ b/contracts/mocks/MockERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {ERC721PresetMinterPauserAutoId} from "@openzeppelin/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoId.sol";

--- a/contracts/mocks/MockLoan.sol
+++ b/contracts/mocks/MockLoan.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../interfaces/ILoan.sol";

--- a/contracts/mocks/MockVeriteAccessControl.sol
+++ b/contracts/mocks/MockVeriteAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import {VeriteAccessControl} from "../permissioned/VeriteAccessControl.sol";

--- a/contracts/mocks/PoolLibTestWrapper.sol
+++ b/contracts/mocks/PoolLibTestWrapper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../libraries/PoolLib.sol";

--- a/contracts/mocks/upgrades/LoanMockV2.sol
+++ b/contracts/mocks/upgrades/LoanMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../Loan.sol";

--- a/contracts/mocks/upgrades/MockBeaconImplementation.sol
+++ b/contracts/mocks/upgrades/MockBeaconImplementation.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../upgrades/BeaconImplementation.sol";

--- a/contracts/mocks/upgrades/MockBeaconProxyFactory.sol
+++ b/contracts/mocks/upgrades/MockBeaconProxyFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../upgrades/BeaconProxyFactory.sol";

--- a/contracts/mocks/upgrades/MockUpgrade.sol
+++ b/contracts/mocks/upgrades/MockUpgrade.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 abstract contract MockUpgrade {

--- a/contracts/mocks/upgrades/PoolAccessControlMockV2.sol
+++ b/contracts/mocks/upgrades/PoolAccessControlMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../permissioned/PoolAccessControl.sol";

--- a/contracts/mocks/upgrades/PoolAdminAccessControlMockV2.sol
+++ b/contracts/mocks/upgrades/PoolAdminAccessControlMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../permissioned/PoolAdminAccessControl.sol";

--- a/contracts/mocks/upgrades/PoolControllerMockV2.sol
+++ b/contracts/mocks/upgrades/PoolControllerMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../controllers/PoolController.sol";

--- a/contracts/mocks/upgrades/PoolMockV2.sol
+++ b/contracts/mocks/upgrades/PoolMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../Pool.sol";

--- a/contracts/mocks/upgrades/ServiceConfigurationMockV2.sol
+++ b/contracts/mocks/upgrades/ServiceConfigurationMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../ServiceConfiguration.sol";

--- a/contracts/mocks/upgrades/WithdrawControllerMockV2.sol
+++ b/contracts/mocks/upgrades/WithdrawControllerMockV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../../controllers/WithdrawController.sol";

--- a/contracts/permissioned/PermissionedLoan.sol
+++ b/contracts/permissioned/PermissionedLoan.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../Loan.sol";

--- a/contracts/permissioned/PermissionedLoanFactory.sol
+++ b/contracts/permissioned/PermissionedLoanFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IPermissionedServiceConfiguration.sol";

--- a/contracts/permissioned/PermissionedPool.sol
+++ b/contracts/permissioned/PermissionedPool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../Pool.sol";

--- a/contracts/permissioned/PermissionedPoolFactory.sol
+++ b/contracts/permissioned/PermissionedPoolFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IPermissionedServiceConfiguration.sol";

--- a/contracts/permissioned/PermissionedServiceConfiguration.sol
+++ b/contracts/permissioned/PermissionedServiceConfiguration.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IPoolAdminAccessControl.sol";

--- a/contracts/permissioned/PoolAccessControl.sol
+++ b/contracts/permissioned/PoolAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IPoolAccessControl.sol";

--- a/contracts/permissioned/PoolAccessControlFactory.sol
+++ b/contracts/permissioned/PoolAccessControlFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IPoolAccessControlFactory.sol";

--- a/contracts/permissioned/PoolAdminAccessControl.sol
+++ b/contracts/permissioned/PoolAdminAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IPoolAdminAccessControl.sol";

--- a/contracts/permissioned/ToSAcceptanceRegistry.sol
+++ b/contracts/permissioned/ToSAcceptanceRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IToSAcceptanceRegistry.sol";

--- a/contracts/permissioned/VeriteAccessControl.sol
+++ b/contracts/permissioned/VeriteAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./interfaces/IVeriteAccessControl.sol";

--- a/contracts/permissioned/interfaces/IPermissionedServiceConfiguration.sol
+++ b/contracts/permissioned/interfaces/IPermissionedServiceConfiguration.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "./IPoolAdminAccessControl.sol";

--- a/contracts/permissioned/interfaces/IPoolAccessControl.sol
+++ b/contracts/permissioned/interfaces/IPoolAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/permissioned/interfaces/IPoolAccessControlFactory.sol
+++ b/contracts/permissioned/interfaces/IPoolAccessControlFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/permissioned/interfaces/IPoolAdminAccessControl.sol
+++ b/contracts/permissioned/interfaces/IPoolAdminAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/permissioned/interfaces/IToSAcceptanceRegistry.sol
+++ b/contracts/permissioned/interfaces/IToSAcceptanceRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/permissioned/interfaces/IVeriteAccessControl.sol
+++ b/contracts/permissioned/interfaces/IVeriteAccessControl.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**

--- a/contracts/upgrades/BeaconImplementation.sol
+++ b/contracts/upgrades/BeaconImplementation.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/upgrades/BeaconProxyFactory.sol
+++ b/contracts/upgrades/BeaconProxyFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "../interfaces/IServiceConfiguration.sol";

--- a/contracts/upgrades/DeployerUUPSUpgradeable.sol
+++ b/contracts/upgrades/DeployerUUPSUpgradeable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/upgrades/interfaces/IBeacon.sol
+++ b/contracts/upgrades/interfaces/IBeacon.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
 /**


### PR DESCRIPTION
Changes the top of each file to MIT license according to
https://docs.soliditylang.org/en/v0.6.8/layout-of-source-files.html#spdx-license-identifier