### PR TITLE
VAL-132 Allow cancellation of full requested balance

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -596,7 +596,6 @@ contract Pool is IPool, ERC20Upgradeable, BeaconImplementation {
             "Pool: InsufficientBalance"
         );
         uint256 feeShares = poolController.requestCancellationFee(shares);
-
         _burn(owner, feeShares);
         withdrawController.performRequestCancellation(owner, shares);
 

--- a/test/libraries/PoolLib.test.ts
+++ b/test/libraries/PoolLib.test.ts
@@ -879,7 +879,7 @@ describe("PoolLib", () => {
       ).to.equal(72);
     });
 
-    it("returns the number of shares minus fees", async () => {
+    it("returns the number of shares irrespective of fees ", async () => {
       const { poolLibWrapper } = await loadFixture(deployFixture);
 
       const fees = 1200; // 12%
@@ -892,7 +892,7 @@ describe("PoolLib", () => {
 
       expect(
         await poolLibWrapper.calculateMaxCancellation(withdrawState, fees)
-      ).to.equal(63);
+      ).to.equal(72);
     });
   });
 });

--- a/test/scenarios/pool/withdraw-request.test.ts
+++ b/test/scenarios/pool/withdraw-request.test.ts
@@ -96,7 +96,7 @@ describe("Withdraw Requests", () => {
         (100 /* initial balance */ -
           50 /* requested */ -
           5) /* previous request fee */ *
-        0.9 /* sub the request fee */
+          0.9 /* sub the request fee */
       )
     );
     expect(await pool.maxWithdrawRequest(aliceLender.address)).to.equal(41);
@@ -107,7 +107,7 @@ describe("Withdraw Requests", () => {
         (70 /* initial balance */ -
           10 /* requested */ -
           1) /* previous request fee */ *
-        0.9 /* sub the request fee */
+          0.9 /* sub the request fee */
       )
     );
     expect(await pool.maxWithdrawRequest(bobLender.address)).to.equal(54);
@@ -148,8 +148,8 @@ describe("Withdraw Requests", () => {
     expect(await pool.maxWithdraw(bobLender.address)).to.equal(6);
 
     // Cancel a request
-    expect(await pool.maxRequestCancellation(aliceLender.address)).to.equal(16);
-    expect(await pool.maxRequestCancellation(bobLender.address)).to.equal(3);
+    expect(await pool.maxRequestCancellation(aliceLender.address)).to.equal(17);
+    expect(await pool.maxRequestCancellation(bobLender.address)).to.equal(4);
 
     // Cancel Bob's request
     const bobBalance = await pool.balanceOf(bobLender.address);
@@ -157,10 +157,10 @@ describe("Withdraw Requests", () => {
 
     // Expect a fee to be paid
     expect(await pool.balanceOf(bobLender.address)).to.equal(bobBalance.sub(1));
-    expect(await pool.maxRequestCancellation(bobLender.address)).to.equal(0);
+    expect(await pool.maxRequestCancellation(bobLender.address)).to.equal(1);
   });
 
-  it.only("allows canceling a full request balance", async () => {
+  it("allows canceling a full request balance", async () => {
     const { pool, aliceLender, bobLender, withdrawController } =
       await loadFixture(loadPoolFixture);
 


### PR DESCRIPTION
The first commit adds a failing test, with a comment, demonstrating how a full `requestedBalance` can't be zeroed out. 2nd commit adds the fix. 

Previously, `maxRequestCancellation` would return `total requested and eligible balance MINUS fees applied against that total`. Then, when canceling, the fees would be burned, and then canceled amount would be subtracted from your requestedBalance. With fee > 0, this is always strictly less than your total requested balance, preventing a full cancel. 

With this change, `maxRequestCancellation` just returns the requested balance. 



