### PR TITLE
VAL-144 [Re-opened] Update maxRedeemRequest, maxWithdrawRequest, maxRequestCancellation to return 0 if a claim is required

### DIFF
--- a/contracts/controllers/WithdrawController.sol
+++ b/contracts/controllers/WithdrawController.sol
@@ -176,8 +176,13 @@ contract WithdrawController is IWithdrawController, BeaconImplementation {
         view
         returns (uint256 maxShares)
     {
+        IPoolWithdrawState memory state = _currentWithdrawState(owner);
+        if (_claimRequired(state)) {
+            return 0;
+        }
+
         maxShares = PoolLib.calculateMaxRedeemRequest(
-            _currentWithdrawState(owner),
+            state,
             _pool.balanceOf(owner),
             _pool.settings().requestFeeBps
         );
@@ -336,9 +341,12 @@ contract WithdrawController is IWithdrawController, BeaconImplementation {
         view
         returns (uint256 maxShares)
     {
-        maxShares = PoolLib.calculateMaxCancellation(
-            _currentWithdrawState(owner)
-        );
+        IPoolWithdrawState memory state = _currentWithdrawState(owner);
+        if (_claimRequired(state)) {
+            return 0;
+        }
+
+        maxShares = PoolLib.calculateMaxCancellation(state);
     }
 
     /**

--- a/test/Pool.test.ts
+++ b/test/Pool.test.ts
@@ -907,6 +907,24 @@ describe("Pool", () => {
 
         expect(await pool.maxRedeemRequest(otherAccount.address)).to.equal(43);
       });
+
+      it("returns 0 if a lender needs to claim snapshots", async () => {
+        const { pool, poolAdmin, otherAccount, liquidityAsset } =
+          await loadFixture(loadPoolFixture);
+        await activatePool(pool, poolAdmin, liquidityAsset);
+        await depositToPool(pool, otherAccount, liquidityAsset, 100);
+        await pool.connect(otherAccount).requestRedeem(50);
+
+        await time.increase(
+          (
+            await pool.settings()
+          ).withdrawRequestPeriodDuration
+        );
+        await pool.snapshot();
+
+        expect(await pool.claimRequired(otherAccount.address)).to.be.true;
+        expect(await pool.maxRedeemRequest(otherAccount.address)).to.equal(0);
+      });
     });
 
     describe("previewRedeemRequest", () => {
@@ -1055,6 +1073,24 @@ describe("Pool", () => {
         expect(await pool.maxWithdrawRequest(otherAccount.address)).to.equal(
           44
         );
+      });
+
+      it("returns 0 if a lender needs to claim snapshots", async () => {
+        const { pool, poolAdmin, otherAccount, liquidityAsset } =
+          await loadFixture(loadPoolFixture);
+        await activatePool(pool, poolAdmin, liquidityAsset);
+        await depositToPool(pool, otherAccount, liquidityAsset, 100);
+        await pool.connect(otherAccount).requestRedeem(50);
+
+        await time.increase(
+          (
+            await pool.settings()
+          ).withdrawRequestPeriodDuration
+        );
+        await pool.snapshot();
+
+        expect(await pool.claimRequired(otherAccount.address)).to.be.true;
+        expect(await pool.maxWithdrawRequest(otherAccount.address)).to.equal(0);
       });
     });
 
@@ -1257,6 +1293,38 @@ describe("Pool", () => {
 
         // Should be zero
         expect(await pool.maxWithdraw(otherAccount.address)).to.equal(0);
+      });
+    });
+
+    describe("maxRequestCancellation()", () => {
+      it("returns the max you can cancel", async () => {
+        const { pool, poolAdmin, liquidityAsset, otherAccount } =
+          await loadFixture(loadPoolFixture);
+        await activatePool(pool, poolAdmin, liquidityAsset);
+        await depositToPool(pool, otherAccount, liquidityAsset, 100);
+
+        await pool.connect(otherAccount).requestRedeem(50);
+        expect(
+          await pool.maxRequestCancellation(otherAccount.address)
+        ).to.equal(50);
+      });
+
+      it("returns 0 if you have unclaimed snapshots", async () => {
+        const { pool, poolAdmin, liquidityAsset, otherAccount } =
+          await loadFixture(loadPoolFixture);
+        await activatePool(pool, poolAdmin, liquidityAsset);
+        await depositToPool(pool, otherAccount, liquidityAsset, 100);
+        await pool.connect(otherAccount).requestRedeem(50);
+
+        await time.increase(
+          (
+            await pool.settings()
+          ).withdrawRequestPeriodDuration
+        );
+        await pool.snapshot();
+        expect(
+          await pool.maxRequestCancellation(otherAccount.address)
+        ).to.equal(0);
       });
     });
   });


### PR DESCRIPTION
Re-opened from: https://github.com/circlefin/valyria-core/pull/187

Since claimRequired must be false in order to make a withdraw request or cancel a portion of a withdraw request, these max* methods now return 0 in case a claim is required. A developer could simply always rely on these max methods now to formulate their request / cancellation. This was a suggestion from ChainSecurity.

You might argue that we should do the same on the following functions, too:

```
previewWithdrawRequest
previewWithdrawRequestFees
previewRedeemRequest
previewRedeemRequestFees
```
But since those function independently of the user's balance, it felt wrong (whereas max* is explicitly based on that balance / withdraw state).