### PR TITLE
ci: upgrade actions to use node 20

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,8 +11,8 @@ jobs:
     name: "Verify"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "npm"


### PR DESCRIPTION
## Summary
Node 16 is EOL, upgrade action versions to use node 20

## Release Notes
* actions/checkout v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
* actions/setup-node v3 -> v4: https://github.com/actions/setup-node/releases/tag/v4.0.0